### PR TITLE
Add optional gid attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following attributes are required for each user:
 * name - The full name of the user (gecos field)
 * uid - The numeric user id for the user. This is required for uid consistency
   across systems.
+* gid - The numeric group id for the group (optional). Otherwise, the
+  uid will be used
 * password - If a hash is provided then that will be used, but otherwise the
   account will be locked
 * groups - a list of supplementary groups for the user.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
   tags: ['users','groups','configuration']
 
 - name: Per-user group creation
-  group: name="{{item.username}}" gid="{{item.uid}}"
+  group: name="{{item.username}}"
+         gid="{{item.gid if item.gid is defined else item.uid}}"
   with_items: users
   when: users_create_per_user_group
   tags: ['users','configuration']


### PR DESCRIPTION
This may be useful for accommodating systems that have intentional (or perhaps legacy) uid/gid inconsistencies, while leaving the default behavior unchanged
