### PR TITLE
add optional gid argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ In addition, the following items are optional for each user:
 * shell - The user's shell. This defaults to /bin/bash. The default is
   configurable using the users_default_shell variable if you want to give all
   users the same shell, but it is different than /bin/bash.
+* gid - You can specify this option for a user if you do not want their primary
+  group id to be the same as their user id.
 
 Example:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   tags: ['users','groups','configuration']
 
 - name: Per-user group creation
-  group: name="{{item.username}}" gid="{{item.uid}}"
+  group: name="{{item.username}}" gid="{{item.gid if item.gid is defined else item.uid}}"
   with_items: users
   when: users_create_per_user_group
   tags: ['users','configuration']

--- a/tests/add_user.yml
+++ b/tests/add_user.yml
@@ -16,6 +16,15 @@
         uid: 2222
         ssh_key:
           - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVpUJQCOaPg3p5xro9e+1fkGRWNOGrrExiKMqTE91Fwu349bxfMnMzRS0PAERouR9EEL+Ee4Yzhav/uNc35eCtXzACtluXnAncMrQj6pM3IqASynhvXTygHljmcMbBSDQtLrTZeW+YzIcOgk5UM1yBi26WoUYva2aCr9IRvKdYreAK08OiMdZedpOye0ZdvIYJGcyITwc6YMmrAhP7jZlrk/mDEkf2a4eBp+475o7MJtaC9npqYkToM8vqvx5AGEKqXt7/f1/paOY7KsR+VGPQy6k2RkXjWBsXPesZ3d3XLZHE60wAk0EsuJO8A25+uWSB6ILQeRSYYmGea/WIf6kd noone@throwaway.example.com"
+      - username: ansibletestuser2
+        name: Ansible Users Role Test Fixture Account2
+        groups:
+          - 'users'
+          - 'bin'
+        uid: 2223
+        gid: 3333
+        ssh_key:
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVpUJQCOaPg3p5xro9e+1fkGRWNOGrrExiKMqTE91Fwu349bxfMnMzRS0PAERouR9EEL+Ee4Yzhav/uNc35eCtXzACtluXnAncMrQj6pM3IqASynhvXTygHljmcMbBSDQtLrTZeW+YzIcOgk5UM1yBi26WoUYva2aCr9IRvKdYreAK08OiMdZedpOye0ZdvIYJGcyITwc6YMmrAhP7jZlrk/mDEkf2a4eBp+475o7MJtaC9npqYkToM8vqvx5AGEKqXt7/f1/paOY7KsR+VGPQy6k2RkXjWBsXPesZ3d3XLZHE60wAk0EsuJO8A25+uWSB6ILQeRSYYmGea/WIf6kd noone@throwaway.example.com"
 
 # Test setup
   pre_tasks:
@@ -37,16 +46,25 @@
   tasks:
     - name: Add Users Test | Post-Assertions | Ensure ansibletestuser was created
       command: "grep ansibletestuser /etc/passwd"
+    - name: Add Users Test | Post-Assertions | Ensure ansibletestuser2 was created
+      command: "grep ansibletestuser2 /etc/passwd"
     - name: Add Users Test | Post-Assertions | Ensure ansibletestuser home dir was created
       command: "ls -d /home/ansibletestuser"
+    - name: Add Users Test | Post-Assertions | Ensure ansibletestuser2 home dir was created
+      command: "ls -d /home/ansibletestuser2"
     - name: Add Users Test | Post-Assertions | Ensure ssh key was added
       command: "sudo grep '{{ users[0].ssh_key[0] }}' /home/ansibletestuser/.ssh/authorized_keys"
+    - name: Add Users Test | Post-Assertions | Ensure ansibletestuser2 ssh key was added
+      command: "sudo grep '{{ users[0].ssh_key[0] }}' /home/ansibletestuser2/.ssh/authorized_keys"
     - name: Add Users Test | Post-Assertions | Ensure group was added
       command: "grep 2222 /etc/group"
+    - name: Add Users Test | Post-Assertions | Ensure testuser2 group was added
+      command: "grep 3333 /etc/group"
     - name: Add Users Test |  Post-Assertions | Ensure user was added to requested groups
       command: "grep '^bin.*ansibletestuser' /etc/group"
+    - name: Add Users Test |  Post-Assertions | Ensure user2 was added to requested groups
+      command: "grep '^bin.*ansibletestuser2' /etc/group"
 
 # Test tear-down
   post_tasks:
     - include: cleanup.yml
-

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -6,3 +6,8 @@
 - name: Cleanup | Remove ansibletestuser home dir
   file: state="absent" path="/home/ansibletestuser"
 
+- name: Cleanup | Remove ansibletestuser
+  user: state="absent" name="ansibletestuser2"
+
+- name: Cleanup | Remove ansibletestuser home dir
+  file: state="absent" path="/home/ansibletestuser2"


### PR DESCRIPTION
Add the option to specify a group id for the users primary group. This can be used in instances where the users primary group is already taken and another integer needs to be specified instead. Users can elect not to set an id and everything will work out just fine. Tests will prove it
