### PR TITLE
Removed conflicting quotes for groups user module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   user: name="{{item.username}}"
         group="{{item.username if users_create_per_user_group
             else users_group}}"
-        groups="{{item.groups | join(',')}}"
+        groups={{item.groups | join(',')}}
         shell={{item.shell if item.shell is defined else users_default_shell}}
         password="{{item.password if item.password is defined else '!'}}"
         comment="{{item.name}}"


### PR DESCRIPTION
When adding multiple groups to a user, specifically one in use, it gave a usermod error:

"usermod: user {username} is currently used by process {process ID Number}\n"

By removing the quotes around

groups={{item.groups | join(',')}}

It fixed the issue, since groups in Ansible core user module does not need quotes for a list of users.
