### PR TITLE
add option to specify the users home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following attributes are required for each user:
 
 * username - The user's username.
 * name - The full name of the user (gecos field)
+* home - the home directory of the user to create (optional, defaults to /home/username)
 * uid - The numeric user id for the user. This is required for uid consistency
   across systems.
 * gid - The numeric group id for the group (optional). Otherwise, the
@@ -51,6 +52,7 @@ Example:
         name: Foo Barrington
         groups: ['wheel','systemd-journal']
         uid: 1001
+        home: /local/home/foo
         profile: |
           alias ll='ls -lah'
         ssh_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
     password: "{{item.password if item.password is defined else '!'}}"
     comment: "{{item.name if item.name is defined else ''}}"
     uid: "{{item.uid}}"
+    home: "{{ item.home | default('/home/' + item.username) }}"
     createhome: "{{'yes' if users_create_homedirs else 'no'}}"
   with_items: "{{users}}"
   tags: ['users','configuration']
@@ -29,7 +30,7 @@
   authorized_key:
     user: "{{item.0.username}}"
     key: "{{item.1}}"
-    path: "/home/{{item.0.username}}/.ssh/authorized_keys"
+    path: "{{ item.0.home | default('/home/' + item.0.username) }}/.ssh/authorized_keys"
   with_subelements:
     - "{{users}}"
     - ssh_key
@@ -38,7 +39,7 @@
 - name: Setup user profiles
   blockinfile:
     block: "{{item.profile}}"
-    dest: "/home/{{item.username}}/.profile"
+    dest: "{{ item.home | default('/home/' + item.username) }}/.profile"
     owner: "{{item.username}}"
     group: "{{item.username}}"
     mode: 0644

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -17,3 +17,22 @@
 
   roles:
     - ansible-users
+
+- hosts: localhost
+  remote_user: root
+  vars:
+    users:
+      - name: Ansible Test User2
+        username: ansibletestuser2
+        uid: 2222
+        groups: [users, bin]
+        shell: /bin/sh
+        home: /home/otherdirectory
+        profile: |
+          alias ll='ls -lah'
+          alias cp='cp -iv'
+        ssh_key:
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVpUJQCOaPg3p5xro9e+1fkGRWNOGrrExiKMqTE91Fwu349bxfMnMzRS0PAERouR9EEL+Ee4Yzhav/uNc35eCtXzACtluXnAncMrQj6pM3IqASynhvXTygHljmcMbBSDQtLrTZeW+YzIcOgk5UM1yBi26WoUYva2aCr9IRvKdYreAK08OiMdZedpOye0ZdvIYJGcyITwc6YMmrAhP7jZlrk/mDEkf2a4eBp+475o7MJtaC9npqYkToM8vqvx5AGEKqXt7/f1/paOY7KsR+VGPQy6k2RkXjWBsXPesZ3d3XLZHE60wAk0EsuJO8A25+uWSB6ILQeRSYYmGea/WIf6kd noone@throwaway.example.com"
+
+  roles:
+    - ansible-users

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -24,7 +24,7 @@
     users:
       - name: Ansible Test User2
         username: ansibletestuser2
-        uid: 2222
+        uid: 2223
         groups: [users, bin]
         shell: /bin/sh
         home: /home/otherdirectory


### PR DESCRIPTION
on our systems we need to specify the users home directory, since its not simply `/home/username`. This patch adds the optional value `home` to the user attributes. 

Thanks to PriceChild in #ansible supporting me with this. 