### PR TITLE
Make location of authorized_keys file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Role to manage users on a system.
   specified for the user.
 * users_create_homedirs (default: true) - create home directories for new
   users. Set this to false if you manage home directories separately.
+* authorized_keys_file (default: .ssh/authorized_keys) - Set this if the
+  ssh server is configured to use a non standard authorized keys file.
 
 ## Creating users
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ users_deleted: []
 #     - name: developers
 #       gid: 10000
 groups_to_create: []
+
+authorized_keys_file: ".ssh/authorized_keys"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   authorized_key:
     user: "{{item.0.username}}"
     key: "{{item.1}}"
-    path: "{{ item.0.home | default('/home/' + item.0.username) }}/.ssh/authorized_keys"
+    path: "{{ item.0.home | default('/home/' + item.0.username) }}/{{ authorized_keys_file }}"
   with_subelements:
     - "{{users}}"
     - ssh_key


### PR DESCRIPTION
By default, ssh servers look at .ssh/authorized_keys, but this setting can be changed.  This role currently hard-codes the path of the authorized_keys file to match that default.  The changes in this PR make this a configurable variable.