### PR TITLE
Fix warning in latest version of ansible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,5 +63,5 @@
 - name: Deleted per-user group removal
   group: name="{{item.username}}" state=absent
   with_items: "{{users_deleted}}"
-  when: users_create_per_user_group
+  when: users_create_per_user_group | bool
   tags: ['users','configuration']


### PR DESCRIPTION
I am seeing this warning when using this module with ansible 2.8.0:

```
[DEPRECATION WARNING]: evaluating users_create_per_user_group as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the
future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

The change in this pull request stops the warning.