### PR TITLE
Aadd support for change owner/group/mode of home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The following attributes are required for each user:
 * username - The user's username.
 * name - The full name of the user (gecos field).
 * home - The home directory of the user to create (optional, defaults to /home/username).
+* home_owner - The home directory owner(optional)
+* home_group - The home directory group(optional)
+* home_mode - The home directory mode(optional)
 * uid - The numeric user id for the user (optional). This is required for uid consistency
   across systems.
 * gid - The numeric group id for the group (optional). Otherwise, the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,14 @@
   with_items: "{{users}}"
   tags: ['users','configuration']
 
+- name: Set home owner and group
+  file:
+    path: "{{ item.home | default('/home/' + item.username) }}"
+    owner: "{{ item.home_owner | default(omit) }}"
+    group: "{{ item.home_group | default(omit) }}"
+    mode: "{{ item.home_mode | default(omit) }}"
+  with_items: "{{ users }}"
+
 - name: SSH keys
   authorized_key:
     user: "{{item.0.username}}"


### PR DESCRIPTION
My use case: I use user home directories as apache websites. Every website group has to be www-data and mode to be 750.