### PR TITLE
 This to remove the existing keys if it is not present in the keys

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
     user: "{{ item.0.username }}"
     key: "{{ item.1 }}"
     path: "{{ item.0.home | default('/home/' + item.0.username) }}/{{ authorized_keys_file }}"
+    exclusive: yes
   with_subelements:
     - "{{ users }}"
     - ssh_key


### PR DESCRIPTION
In the authorized_keys module used in this role is updated with exclusive attribute . It would be addressing the issue raised in the Removing ssh keys #56.  